### PR TITLE
version 2.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 set(LIBNAME "ev3-cpp-template-wrapper-lib")
-project(${LIBNAME} VERSION 2.0.0)
+project(${LIBNAME} VERSION 2.5.1)
 message(STATUS ${CMAKE_CXX_FLAGS})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ aimed at providing support for a few other sensors (compass and irseeker etc) an
 
 only works on windows
 Find the documentation [here](rshs-robotics-club.github.io)
+
+# we are currently on version V2.5.1

--- a/lib/motor/ev3wrapmotor.cpp
+++ b/lib/motor/ev3wrapmotor.cpp
@@ -134,5 +134,5 @@ bool Ev3Wrap::Motor::waitUntilStalled(float timeoutMilliseconds) {
 }
 
 float Ev3Wrap::Motor::getMaxRpm() {
-    return this->max_speed() * 60 * (1 / (this->count_per_rot()));
+    return ((float)(this->max_speed())) * 60.0f * (1.0f / (float)(this->count_per_rot()));
 }


### PR DESCRIPTION
- [x] emergency `float Motor.getMaxRpm()` fix (error was due to accidental integer division)