### PR TITLE
2.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 set(LIBNAME "ev3-cpp-template-wrapper-lib")
-project(${LIBNAME} VERSION 2.5.1)
+project(${LIBNAME} VERSION 2.5.2)
 message(STATUS ${CMAKE_CXX_FLAGS})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/lib/omnirobot/ev3wrapomnirobot.cpp
+++ b/lib/omnirobot/ev3wrapomnirobot.cpp
@@ -32,7 +32,7 @@ Omni::Omni(IrSeeker& irSeeker, CompassSensor& compass) : irSeeker(irSeeker), com
 
 Omni& Omni::controlRaw(float eSpeed, float fSpeed, float gSpeed, float hSpeed) {
     #ifdef DEBUG_MODE_ENABLED
-    #define MOMS 100 // MaxOmniMotorSpeed
+    #define MOMS 201 // MaxOmniMotorSpeed
     if (eSpeed > MOMS || fSpeed > MOMS || gSpeed > MOMS || hSpeed > MOMS) {
         throw std::invalid_argument("e: "+std::to_string(eSpeed)+" | "
                                     "f: "+std::to_string(fSpeed)+" | "


### PR DESCRIPTION
Includes some simple fixes (just like 2.5.1)

Increase maximum omni motor speed to 201 (the original 100 was way too low and was limiting)